### PR TITLE
Fix broken pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 version = '0.0.1'
 
 setup(
+    name='''ckanext-moeiemailer''',
     entry_points='''
         [ckan.plugins]
         moeiemailer=ckanext.moeiemailer.plugin:MailerMoei


### PR DESCRIPTION
Adds the name of the extension that is missing in the setup.py.